### PR TITLE
feat: configurable monthly start day

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Personal Money Manager
+
+A simple personal finance manager built with Next.js and PostgreSQL.
+
+## Setup
+
+1. Install dependencies:
+   ```sh
+   pnpm install
+   ```
+2. Run the SQL scripts in the `scripts/` directory to set up the database schema.
+3. Start the development server:
+   ```sh
+   pnpm dev
+   ```
+
+## Monthly Start Day
+
+User settings now include a **Monthly Start Day** (1‑31) that defaults to `1`. This value controls how "This Month" ranges are calculated across overviews, budgets and data exports. You can configure it from **Settings → General** in the application.

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -35,8 +35,15 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     }
 
-    const settings = await request.json()
-    await updateUserSettings(userId, settings)
+    const { currency, dateFormat, theme, notificationsEnabled, autoBackup, monthlyStartDay } = await request.json()
+    await updateUserSettings(userId, {
+      currency,
+      dateFormat,
+      theme,
+      notificationsEnabled,
+      autoBackup,
+      monthlyStartDay,
+    })
 
     return NextResponse.json({ success: true })
   } catch (error) {

--- a/components/budget.tsx
+++ b/components/budget.tsx
@@ -19,6 +19,8 @@ import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Progress } from "@/components/ui/progress"
 import { Plus, Edit, Trash2, Target, AlertTriangle, CheckCircle } from "lucide-react"
+import { apiClient } from "@/lib/api-client"
+import { getMonthlyDateRange } from "@/lib/utils"
 
 interface Budget {
   id: string
@@ -32,6 +34,7 @@ interface Budget {
 export function Budget() {
   const [budgets, setBudgets] = useState<Budget[]>([])
   const [transactions, setTransactions] = useState([])
+  const [monthlyStartDay, setMonthlyStartDay] = useState(1)
   const [isDialogOpen, setIsDialogOpen] = useState(false)
   const [editingBudget, setEditingBudget] = useState<Budget | null>(null)
   const [formData, setFormData] = useState({
@@ -59,6 +62,11 @@ export function Budget() {
     const storedTransactions = JSON.parse(localStorage.getItem("money-manager-transactions") || "[]")
     setBudgets(storedBudgets)
     setTransactions(storedTransactions)
+
+    apiClient
+      .get("/api/settings")
+      .then((s) => setMonthlyStartDay(s?.monthly_start_day || 1))
+      .catch(() => {})
   }, [])
 
   const saveBudgets = (newBudgets: Budget[]) => {
@@ -77,33 +85,9 @@ export function Budget() {
         endDate.setDate(startDate.getDate() + 6)
         break
       case "monthly":
-        // Custom month: 25th to 24th
-        const currentDate = now.getDate()
-        let startMonth, startYear, endMonth, endYear
-
-        if (currentDate >= 25) {
-          startMonth = now.getMonth()
-          startYear = now.getFullYear()
-          endMonth = now.getMonth() + 1
-          endYear = now.getFullYear()
-        } else {
-          startMonth = now.getMonth() - 1
-          startYear = now.getFullYear()
-          endMonth = now.getMonth()
-          endYear = now.getFullYear()
-        }
-
-        if (startMonth < 0) {
-          startMonth = 11
-          startYear--
-        }
-        if (endMonth > 11) {
-          endMonth = 0
-          endYear++
-        }
-
-        startDate = new Date(startYear, startMonth, 25)
-        endDate = new Date(endYear, endMonth, 24)
+        const { startDate: start, endDate: end } = getMonthlyDateRange(monthlyStartDay)
+        startDate = start
+        endDate = end
         break
       case "yearly":
         startDate = new Date(now.getFullYear(), 0, 1)

--- a/components/data-export.tsx
+++ b/components/data-export.tsx
@@ -1,15 +1,27 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Download, FileSpreadsheet, FileText } from "lucide-react"
+import { apiClient } from "@/lib/api-client"
+import { getMonthlyDateRange } from "@/lib/utils"
 
 export function DataExport() {
   const [exportFormat, setExportFormat] = useState("xlsx")
   const [exportType, setExportType] = useState("all")
   const [dateRange, setDateRange] = useState("all")
+  const [monthlyStartDay, setMonthlyStartDay] = useState(1)
+
+  useEffect(() => {
+    apiClient
+      .get("/api/settings")
+      .then((s) => setMonthlyStartDay(s?.monthly_start_day || 1))
+      .catch(() => {})
+  }, [])
+
+  const { startDate: currentStart, endDate: currentEnd } = getMonthlyDateRange(monthlyStartDay)
 
   const exportData = () => {
     const accounts = JSON.parse(localStorage.getItem("money-manager-accounts") || "[]")
@@ -26,23 +38,7 @@ export function DataExport() {
 
       switch (dateRange) {
         case "thisMonth":
-          const currentDate = now.getDate()
-          let startMonth, startYear
-
-          if (currentDate >= 25) {
-            startMonth = now.getMonth()
-            startYear = now.getFullYear()
-          } else {
-            startMonth = now.getMonth() - 1
-            startYear = now.getFullYear()
-          }
-
-          if (startMonth < 0) {
-            startMonth = 11
-            startYear--
-          }
-
-          startDate = new Date(startYear, startMonth, 25)
+          startDate = getMonthlyDateRange(monthlyStartDay).startDate
           break
         case "last3Months":
           startDate = new Date()
@@ -254,7 +250,9 @@ export function DataExport() {
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">All Time</SelectItem>
-                <SelectItem value="thisMonth">This Month (25th-24th)</SelectItem>
+                <SelectItem value="thisMonth">
+                  {`This Month (${currentStart.getDate()}-${currentEnd.getDate()})`}
+                </SelectItem>
                 <SelectItem value="last3Months">Last 3 Months</SelectItem>
                 <SelectItem value="thisYear">This Year</SelectItem>
               </SelectContent>

--- a/components/overview.tsx
+++ b/components/overview.tsx
@@ -17,6 +17,7 @@ import {
   Loader2,
 } from "lucide-react"
 import { apiClient } from "@/lib/api-client"
+import { getMonthlyDateRange } from "@/lib/utils"
 
 interface Account {
   id: string
@@ -49,6 +50,7 @@ export function Overview() {
   const [budgets, setBudgets] = useState<Budget[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [monthlyStartDay, setMonthlyStartDay] = useState(1)
 
   useEffect(() => {
     loadData()
@@ -59,15 +61,17 @@ export function Overview() {
     setError(null)
 
     try {
-      const [accountsData, transactionsData, budgetsData] = await Promise.all([
+      const [accountsData, transactionsData, budgetsData, settingsData] = await Promise.all([
         apiClient.get("/api/accounts"),
         apiClient.get("/api/transactions"),
         apiClient.get("/api/budgets"),
+        apiClient.get("/api/settings"),
       ])
 
       setAccounts(accountsData || [])
       setTransactions(transactionsData || [])
       setBudgets(budgetsData || [])
+      setMonthlyStartDay(settingsData?.monthly_start_day || 1)
     } catch (error) {
       console.error("Error loading overview data:", error)
       setError("Failed to load overview data. Please refresh the page.")
@@ -80,39 +84,8 @@ export function Overview() {
 
   const getFilteredTransactions = () => {
     const now = new Date()
-
-    const getCustomMonthRange = () => {
-      const currentDate = now.getDate()
-      let startMonth, startYear, endMonth, endYear
-
-      if (currentDate >= 25) {
-        startMonth = now.getMonth()
-        startYear = now.getFullYear()
-        endMonth = now.getMonth() + 1
-        endYear = now.getFullYear()
-      } else {
-        startMonth = now.getMonth() - 1
-        startYear = now.getFullYear()
-        endMonth = now.getMonth()
-        endYear = now.getFullYear()
-      }
-
-      if (startMonth < 0) {
-        startMonth = 11
-        startYear--
-      }
-      if (endMonth > 11) {
-        endMonth = 0
-        endYear++
-      }
-
-      const startDate = new Date(startYear, startMonth, 25)
-      const endDate = new Date(endYear, endMonth, 24, 23, 59, 59)
-
-      return { startDate, endDate }
-    }
-
-    const startOfWeek = new Date(now.setDate(now.getDate() - now.getDay()))
+    const startOfWeek = new Date(now)
+    startOfWeek.setDate(startOfWeek.getDate() - startOfWeek.getDay())
 
     return transactions.filter((transaction) => {
       const transactionDate = new Date(transaction.transaction_date)
@@ -120,7 +93,7 @@ export function Overview() {
         case "thisWeek":
           return transactionDate >= startOfWeek
         case "thisMonth":
-          const { startDate, endDate } = getCustomMonthRange()
+          const { startDate, endDate } = getMonthlyDateRange(monthlyStartDay, new Date())
           return transactionDate >= startDate && transactionDate <= endDate
         case "last30Days":
           const thirtyDaysAgo = new Date()

--- a/components/settings.tsx
+++ b/components/settings.tsx
@@ -36,6 +36,7 @@ export function Settings() {
     theme: "light",
     notificationsEnabled: true,
     autoBackup: true,
+    monthlyStartDay: 1,
   })
   const [newPassword, setNewPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
@@ -57,6 +58,7 @@ export function Settings() {
           theme: userSettings.theme || "light",
           notificationsEnabled: userSettings.notifications_enabled ?? true,
           autoBackup: userSettings.auto_backup ?? true,
+          monthlyStartDay: userSettings.monthly_start_day || 1,
         })
       }
     } catch (error) {
@@ -73,6 +75,7 @@ export function Settings() {
         theme: settings.theme,
         notificationsEnabled: settings.notificationsEnabled,
         autoBackup: settings.autoBackup,
+        monthlyStartDay: settings.monthlyStartDay,
       })
       setMessage({ type: "success", text: "Settings saved successfully!" })
     } catch (error) {
@@ -219,6 +222,27 @@ export function Settings() {
                       <SelectItem value="light">Light</SelectItem>
                       <SelectItem value="dark">Dark</SelectItem>
                       <SelectItem value="auto">Auto</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-3">
+                  <Label htmlFor="monthlyStartDay">Monthly Start Day</Label>
+                  <Select
+                    value={settings.monthlyStartDay.toString()}
+                    onValueChange={(value) =>
+                      setSettings({ ...settings, monthlyStartDay: Number(value) })
+                    }
+                  >
+                    <SelectTrigger className="h-12 rounded-2xl">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {Array.from({ length: 31 }, (_, i) => (
+                        <SelectItem key={i + 1} value={(i + 1).toString()}>
+                          {i + 1}
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </div>

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -201,19 +201,21 @@ export async function changePassword(userId: string, newPassword: string): Promi
 
 export async function getUserSettings(userId: string) {
   const [settings] = await sql`
-    SELECT * FROM user_settings WHERE user_id = ${userId}
+    SELECT currency, date_format, theme, notifications_enabled, auto_backup, monthly_start_day
+    FROM user_settings WHERE user_id = ${userId}
   `
   return settings
 }
 
 export async function updateUserSettings(userId: string, settings: any) {
   await sql`
-    UPDATE user_settings 
+    UPDATE user_settings
     SET currency = ${settings.currency || "IDR"},
         date_format = ${settings.dateFormat || "DD/MM/YYYY"},
         theme = ${settings.theme || "light"},
         notifications_enabled = ${settings.notificationsEnabled || true},
-        auto_backup = ${settings.autoBackup || true}
+        auto_backup = ${settings.autoBackup || true},
+        monthly_start_day = ${settings.monthlyStartDay || 1}
     WHERE user_id = ${userId}
   `
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,41 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function getMonthlyDateRange(
+  startDay = 1,
+  referenceDate = new Date(),
+) {
+  const date = new Date(referenceDate)
+  let startYear = date.getFullYear()
+  let startMonth = date.getMonth()
+
+  if (date.getDate() < startDay) {
+    startMonth -= 1
+    if (startMonth < 0) {
+      startMonth = 11
+      startYear -= 1
+    }
+  }
+
+  const startDayClamped = Math.min(
+    startDay,
+    new Date(startYear, startMonth + 1, 0).getDate(),
+  )
+  const startDate = new Date(startYear, startMonth, startDayClamped)
+
+  let nextYear = startDate.getFullYear()
+  let nextMonth = startDate.getMonth() + 1
+  if (nextMonth > 11) {
+    nextMonth = 0
+    nextYear += 1
+  }
+  const nextStartDayClamped = Math.min(
+    startDay,
+    new Date(nextYear, nextMonth + 1, 0).getDate(),
+  )
+  const endDate = new Date(nextYear, nextMonth, nextStartDayClamped)
+  endDate.setDate(endDate.getDate() - 1)
+
+  return { startDate, endDate }
+}

--- a/scripts/003_update_user_system.sql
+++ b/scripts/003_update_user_system.sql
@@ -25,9 +25,22 @@ CREATE TABLE IF NOT EXISTS user_settings (
     theme VARCHAR(20) DEFAULT 'light',
     notifications_enabled BOOLEAN DEFAULT TRUE,
     auto_backup BOOLEAN DEFAULT TRUE,
+    monthly_start_day INTEGER DEFAULT 1 CHECK (monthly_start_day BETWEEN 1 AND 31),
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
+
+-- Ensure monthly_start_day column exists for existing installations
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'user_settings' AND column_name = 'monthly_start_day'
+    ) THEN
+        ALTER TABLE user_settings
+            ADD COLUMN monthly_start_day INTEGER DEFAULT 1 CHECK (monthly_start_day BETWEEN 1 AND 31);
+    END IF;
+END $$;
 
 -- Add indexes for performance
 CREATE INDEX IF NOT EXISTS idx_user_sessions_user_id ON user_sessions(user_id);

--- a/scripts/003_update_user_system_fixed.sql
+++ b/scripts/003_update_user_system_fixed.sql
@@ -49,9 +49,22 @@ CREATE TABLE IF NOT EXISTS user_settings (
     theme VARCHAR(20) DEFAULT 'light',
     notifications_enabled BOOLEAN DEFAULT TRUE,
     auto_backup BOOLEAN DEFAULT TRUE,
+    monthly_start_day INTEGER DEFAULT 1 CHECK (monthly_start_day BETWEEN 1 AND 31),
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
+
+-- Ensure monthly_start_day column exists for existing installations
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'user_settings' AND column_name = 'monthly_start_day'
+    ) THEN
+        ALTER TABLE user_settings
+            ADD COLUMN monthly_start_day INTEGER DEFAULT 1 CHECK (monthly_start_day BETWEEN 1 AND 31);
+    END IF;
+END $$;
 
 -- Add indexes for performance
 CREATE INDEX IF NOT EXISTS idx_user_sessions_user_id ON user_sessions(user_id);


### PR DESCRIPTION
## Summary
- add `monthly_start_day` column to user settings and expose via API
- allow selecting and saving start day in settings UI
- use helper to calculate custom month ranges across overview, budgets, and exports

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e860be448325b133998a229e1142