### PR TITLE
feat: add transaction pagination filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Personal Money Manager
+
+This project is a Next.js application for tracking personal finances.
+
+## Transactions API
+
+The transaction endpoints support optional query parameters to filter and paginate results:
+
+- `startDate` (YYYY-MM-DD) – return transactions on or after this date.
+- `endDate` (YYYY-MM-DD) – return transactions on or before this date.
+- `limit` – maximum number of records to return. Must be a non-negative integer.
+- `offset` – number of records to skip before collecting results. Must be a non-negative integer.
+
+When `startDate` and `endDate` are provided together, transactions are filtered where `transaction_date` falls between the two dates. Invalid dates or negative limits result in a **400 Bad Request** response with a descriptive message.
+
+Responses from `/api/transactions`, `/api/transactions/by-account`, and `/api/transactions/by-category` now include:
+
+```
+{
+  "transactions": [...],
+  "total": 0,
+  "hasMore": false
+}
+```
+
+`total` represents the number of matching transactions, and `hasMore` indicates if more pages are available using the given `limit` and `offset`.
+

--- a/app/api/transactions/by-account/route.ts
+++ b/app/api/transactions/by-account/route.ts
@@ -23,6 +23,8 @@ export async function GET(request: NextRequest) {
 
     const { searchParams } = new URL(request.url)
     const accountId = searchParams.get("accountId")
+    const startDateParam = searchParams.get("startDate")
+    const endDateParam = searchParams.get("endDate")
     const limit = Number.parseInt(searchParams.get("limit") || "50")
     const offset = Number.parseInt(searchParams.get("offset") || "0")
 
@@ -30,29 +32,62 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Account ID required" }, { status: 400 })
     }
 
+    if (Number.isNaN(limit) || Number.isNaN(offset) || limit < 0 || offset < 0) {
+      return NextResponse.json({ error: "Limit and offset must be non-negative integers" }, { status: 400 })
+    }
+
+    let startDate: Date | undefined
+    if (startDateParam) {
+      startDate = new Date(startDateParam)
+      if (isNaN(startDate.getTime())) {
+        return NextResponse.json({ error: "Invalid startDate" }, { status: 400 })
+      }
+    }
+
+    let endDate: Date | undefined
+    if (endDateParam) {
+      endDate = new Date(endDateParam)
+      if (isNaN(endDate.getTime())) {
+        return NextResponse.json({ error: "Invalid endDate" }, { status: 400 })
+      }
+    }
+
+    const conditions = [sql`t.user_id = ${userId}`, sql`t.account_id = ${accountId}`]
+    if (startDate && endDate) {
+      conditions.push(sql`t.transaction_date BETWEEN ${startDate} AND ${endDate}`)
+    } else if (startDate) {
+      conditions.push(sql`t.transaction_date >= ${startDate}`)
+    } else if (endDate) {
+      conditions.push(sql`t.transaction_date <= ${endDate}`)
+    }
+
+    const whereClause = sql.join(conditions, sql` AND `)
+
     const transactions = await sql`
-      SELECT 
+      SELECT
         t.*,
         a.name as account_name,
         c.name as category_name
       FROM transactions t
       LEFT JOIN accounts a ON t.account_id = a.id
       LEFT JOIN categories c ON t.category_id = c.id
-      WHERE t.user_id = ${userId} AND t.account_id = ${accountId}
+      WHERE ${whereClause}
       ORDER BY t.transaction_date DESC, t.created_at DESC
       LIMIT ${limit} OFFSET ${offset}
     `
 
     const [{ count }] = await sql`
-      SELECT COUNT(*) as count 
-      FROM transactions 
-      WHERE user_id = ${userId} AND account_id = ${accountId}
+      SELECT COUNT(*) as count
+      FROM transactions t
+      WHERE ${whereClause}
     `
+
+    const total = Number.parseInt(count as any)
 
     return NextResponse.json({
       transactions,
-      total: Number.parseInt(count),
-      hasMore: offset + limit < Number.parseInt(count),
+      total,
+      hasMore: offset + limit < total,
     })
   } catch (error) {
     console.error("Get transactions by account error:", error)

--- a/app/api/transactions/by-category/route.ts
+++ b/app/api/transactions/by-category/route.ts
@@ -24,60 +24,97 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url)
     const categoryId = searchParams.get("categoryId")
     const categoryName = searchParams.get("categoryName")
+    const startDateParam = searchParams.get("startDate")
+    const endDateParam = searchParams.get("endDate")
     const limit = Number.parseInt(searchParams.get("limit") || "50")
     const offset = Number.parseInt(searchParams.get("offset") || "0")
 
+    if (Number.isNaN(limit) || Number.isNaN(offset) || limit < 0 || offset < 0) {
+      return NextResponse.json({ error: "Limit and offset must be non-negative integers" }, { status: 400 })
+    }
+
+    let startDate: Date | undefined
+    if (startDateParam) {
+      startDate = new Date(startDateParam)
+      if (isNaN(startDate.getTime())) {
+        return NextResponse.json({ error: "Invalid startDate" }, { status: 400 })
+      }
+    }
+
+    let endDate: Date | undefined
+    if (endDateParam) {
+      endDate = new Date(endDateParam)
+      if (isNaN(endDate.getTime())) {
+        return NextResponse.json({ error: "Invalid endDate" }, { status: 400 })
+      }
+    }
+
     let transactions, count
 
+    const conditionsBase = []
+    if (startDate && endDate) {
+      conditionsBase.push(sql`t.transaction_date BETWEEN ${startDate} AND ${endDate}`)
+    } else if (startDate) {
+      conditionsBase.push(sql`t.transaction_date >= ${startDate}`)
+    } else if (endDate) {
+      conditionsBase.push(sql`t.transaction_date <= ${endDate}`)
+    }
+
     if (categoryId) {
+      const conditions = [sql`t.user_id = ${userId}`, sql`t.category_id = ${categoryId}`, ...conditionsBase]
+      const where = sql.join(conditions, sql` AND `)
       transactions = await sql`
-        SELECT 
+        SELECT
           t.*,
           a.name as account_name,
           c.name as category_name
         FROM transactions t
         LEFT JOIN accounts a ON t.account_id = a.id
         LEFT JOIN categories c ON t.category_id = c.id
-        WHERE t.user_id = ${userId} AND t.category_id = ${categoryId}
+        WHERE ${where}
         ORDER BY t.transaction_date DESC, t.created_at DESC
         LIMIT ${limit} OFFSET ${offset}
       `
 
       const [countResult] = await sql`
-        SELECT COUNT(*) as count 
-        FROM transactions 
-        WHERE user_id = ${userId} AND category_id = ${categoryId}
+        SELECT COUNT(*) as count
+        FROM transactions t
+        WHERE ${where}
       `
       count = countResult.count
     } else if (categoryName) {
+      const conditions = [sql`t.user_id = ${userId}`, sql`c.name = ${categoryName}`, ...conditionsBase]
+      const where = sql.join(conditions, sql` AND `)
       transactions = await sql`
-        SELECT 
+        SELECT
           t.*,
           a.name as account_name,
           c.name as category_name
         FROM transactions t
         LEFT JOIN accounts a ON t.account_id = a.id
         LEFT JOIN categories c ON t.category_id = c.id
-        WHERE t.user_id = ${userId} AND c.name = ${categoryName}
+        WHERE ${where}
         ORDER BY t.transaction_date DESC, t.created_at DESC
         LIMIT ${limit} OFFSET ${offset}
       `
 
       const [countResult] = await sql`
-        SELECT COUNT(*) as count 
+        SELECT COUNT(*) as count
         FROM transactions t
         LEFT JOIN categories c ON t.category_id = c.id
-        WHERE t.user_id = ${userId} AND c.name = ${categoryName}
+        WHERE ${where}
       `
       count = countResult.count
     } else {
       return NextResponse.json({ error: "Category ID or name required" }, { status: 400 })
     }
 
+    const total = Number.parseInt(count as any)
+
     return NextResponse.json({
       transactions,
-      total: Number.parseInt(count),
-      hasMore: offset + limit < Number.parseInt(count),
+      total,
+      hasMore: offset + limit < total,
     })
   } catch (error) {
     console.error("Get transactions by category error:", error)

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -20,9 +20,48 @@ export async function GET(request: NextRequest) {
     if (!userId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     }
+    const { searchParams } = new URL(request.url)
+    const startDateParam = searchParams.get("startDate")
+    const endDateParam = searchParams.get("endDate")
+    const limitParam = searchParams.get("limit")
+    const offsetParam = searchParams.get("offset")
+
+    const limit = Number.parseInt(limitParam || "50")
+    const offset = Number.parseInt(offsetParam || "0")
+
+    if (Number.isNaN(limit) || Number.isNaN(offset) || limit < 0 || offset < 0) {
+      return NextResponse.json({ error: "Limit and offset must be non-negative integers" }, { status: 400 })
+    }
+
+    let startDate: Date | undefined
+    if (startDateParam) {
+      startDate = new Date(startDateParam)
+      if (isNaN(startDate.getTime())) {
+        return NextResponse.json({ error: "Invalid startDate" }, { status: 400 })
+      }
+    }
+
+    let endDate: Date | undefined
+    if (endDateParam) {
+      endDate = new Date(endDateParam)
+      if (isNaN(endDate.getTime())) {
+        return NextResponse.json({ error: "Invalid endDate" }, { status: 400 })
+      }
+    }
+
+    const conditions = []
+    if (startDate && endDate) {
+      conditions.push(sql`t.transaction_date BETWEEN ${startDate} AND ${endDate}`)
+    } else if (startDate) {
+      conditions.push(sql`t.transaction_date >= ${startDate}`)
+    } else if (endDate) {
+      conditions.push(sql`t.transaction_date <= ${endDate}`)
+    }
+
+    const whereClause = conditions.length > 0 ? sql`AND ${sql.join(conditions, sql` AND `)}` : sql``
 
     const transactions = await sql`
-      SELECT 
+      SELECT
         t.id,
         t.type,
         t.amount,
@@ -36,11 +75,24 @@ export async function GET(request: NextRequest) {
       FROM transactions t
       LEFT JOIN accounts a ON t.account_id = a.id
       LEFT JOIN categories c ON t.category_id = c.id
-      WHERE t.user_id = ${userId}
+      WHERE t.user_id = ${userId} ${whereClause}
       ORDER BY t.transaction_date DESC, t.created_at DESC
+      LIMIT ${limit} OFFSET ${offset}
     `
 
-    return NextResponse.json(transactions)
+    const [{ count }] = await sql`
+      SELECT COUNT(*) as count
+      FROM transactions t
+      WHERE t.user_id = ${userId} ${whereClause}
+    `
+
+    const total = Number.parseInt(count as any)
+
+    return NextResponse.json({
+      transactions,
+      total,
+      hasMore: offset + limit < total,
+    })
   } catch (error) {
     console.error("Get transactions error:", error)
     return NextResponse.json({ error: "Failed to load transactions" }, { status: 500 })

--- a/components/overview.tsx
+++ b/components/overview.tsx
@@ -61,12 +61,12 @@ export function Overview() {
     try {
       const [accountsData, transactionsData, budgetsData] = await Promise.all([
         apiClient.get("/api/accounts"),
-        apiClient.get("/api/transactions"),
+        apiClient.get("/api/transactions?limit=100&offset=0"),
         apiClient.get("/api/budgets"),
       ])
 
       setAccounts(accountsData || [])
-      setTransactions(transactionsData || [])
+      setTransactions(transactionsData?.transactions || transactionsData || [])
       setBudgets(budgetsData || [])
     } catch (error) {
       console.error("Error loading overview data:", error)

--- a/components/transaction-history.tsx
+++ b/components/transaction-history.tsx
@@ -5,7 +5,17 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
-import { ArrowLeft, Calendar, TrendingUp, TrendingDown, Search, Filter, ChevronDown, ChevronUp } from "lucide-react"
+import {
+  ArrowLeft,
+  Calendar,
+  TrendingUp,
+  TrendingDown,
+  Search,
+  Filter,
+  ChevronDown,
+  ChevronUp,
+  Loader2,
+} from "lucide-react"
 import { apiClient } from "@/lib/api-client"
 
 interface Transaction {
@@ -42,20 +52,28 @@ export function TransactionHistory({
   const [currentPage, setCurrentPage] = useState(1)
   const [hasMore, setHasMore] = useState(false)
   const [total, setTotal] = useState(0)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const pageSize = 20
 
   useEffect(() => {
-    loadTransactions()
-  }, [accountId, categoryId, currentPage, sortBy, sortOrder, filterType])
+    setCurrentPage(1)
+    loadTransactions(1, false)
+  }, [accountId, categoryId, categoryName])
 
-  const loadTransactions = async () => {
-    setLoading(true)
+  const loadTransactions = async (page: number, append: boolean) => {
+    if (append) {
+      setLoadingMore(true)
+    } else {
+      setLoading(true)
+    }
+    setError(null)
     try {
       let endpoint = ""
       const params = new URLSearchParams({
         limit: pageSize.toString(),
-        offset: ((currentPage - 1) * pageSize).toString(),
+        offset: ((page - 1) * pageSize).toString(),
       })
 
       if (accountId) {
@@ -69,14 +87,21 @@ export function TransactionHistory({
       const response = await apiClient.get(endpoint)
 
       if (response) {
-        setTransactions(response.transactions || [])
+        setTransactions((prev) =>
+          append ? [...prev, ...(response.transactions || [])] : response.transactions || [],
+        )
         setHasMore(response.hasMore || false)
         setTotal(response.total || 0)
       }
-    } catch (error) {
-      console.error("Error loading transactions:", error)
+    } catch (err) {
+      console.error("Error loading transactions:", err)
+      setError("Failed to load transactions")
     } finally {
-      setLoading(false)
+      if (append) {
+        setLoadingMore(false)
+      } else {
+        setLoading(false)
+      }
     }
   }
 
@@ -247,6 +272,7 @@ export function TransactionHistory({
           </CardDescription>
         </CardHeader>
         <CardContent>
+          {error && <p className="text-red-500 text-center mb-4">{error}</p>}
           {loading ? (
             <div className="flex justify-center py-8">
               <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
@@ -308,11 +334,16 @@ export function TransactionHistory({
           {hasMore && (
             <div className="flex justify-center mt-6">
               <Button
-                onClick={() => setCurrentPage(currentPage + 1)}
-                disabled={loading}
+                onClick={() => {
+                  const nextPage = currentPage + 1
+                  setCurrentPage(nextPage)
+                  loadTransactions(nextPage, true)
+                }}
+                disabled={loadingMore}
                 className="gradient-purple border-0 text-white shadow-lg hover:scale-105 transition-all duration-200 rounded-2xl"
               >
-                Load More
+                {loadingMore && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                {loadingMore ? "Loading..." : "Load More"}
               </Button>
             </div>
           )}

--- a/components/transactions.tsx
+++ b/components/transactions.tsx
@@ -73,6 +73,10 @@ export function Transactions() {
   const [isDeleting, setIsDeleting] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
+  const [currentPage, setCurrentPage] = useState(1)
+  const [hasMore, setHasMore] = useState(false)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const pageSize = 20
   const [formData, setFormData] = useState({
     type: "expense",
     amount: "",
@@ -97,20 +101,46 @@ export function Transactions() {
     }
   }, [error, success])
 
+  const loadTransactions = async (page: number) => {
+    if (page > 1) {
+      setIsLoadingMore(true)
+    }
+    try {
+      const params = new URLSearchParams({
+        limit: pageSize.toString(),
+        offset: ((page - 1) * pageSize).toString(),
+      })
+      const response = await apiClient.get(`/api/transactions?${params}`)
+      if (response) {
+        setTransactions((prev) =>
+          page === 1 ? response.transactions || [] : [...prev, ...(response.transactions || [])],
+        )
+        setHasMore(response.hasMore || false)
+      }
+    } catch (error) {
+      console.error("Error loading transactions:", error)
+      setError("Failed to load transaction data. Please refresh the page.")
+    } finally {
+      if (page > 1) {
+        setIsLoadingMore(false)
+      }
+    }
+  }
+
   const loadData = async () => {
     setIsLoading(true)
     setError(null)
 
     try {
-      const [transactionsData, accountsData, categoriesData] = await Promise.all([
-        apiClient.get("/api/transactions"),
+      const [accountsData, categoriesData] = await Promise.all([
         apiClient.get("/api/accounts"),
         apiClient.get("/api/categories"),
       ])
 
-      setTransactions(transactionsData || [])
       setAccounts(accountsData || [])
       setCategories(categoriesData || [])
+      setCurrentPage(1)
+      await loadTransactions(1)
     } catch (error) {
       console.error("Error loading data:", error)
       setError("Failed to load transaction data. Please refresh the page.")
@@ -604,6 +634,23 @@ export function Transactions() {
           </Card>
         ))}
       </div>
+
+      {hasMore && (
+        <div className="flex justify-center mt-6">
+          <Button
+            onClick={() => {
+              const nextPage = currentPage + 1
+              setCurrentPage(nextPage)
+              loadTransactions(nextPage)
+            }}
+            disabled={isLoadingMore}
+            className="gradient-purple border-0 text-white shadow-lg hover:scale-105 transition-all duration-200 rounded-2xl"
+          >
+            {isLoadingMore && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            {isLoadingMore ? "Loading..." : "Load More"}
+          </Button>
+        </div>
+      )}
 
       {/* Empty State */}
       {filteredTransactions.length === 0 && !isLoading && (

--- a/components/transfer.tsx
+++ b/components/transfer.tsx
@@ -66,11 +66,11 @@ export function Transfer() {
     try {
       const [accountsData, transactionsData] = await Promise.all([
         apiClient.get("/api/accounts"),
-        apiClient.get("/api/transactions"),
+        apiClient.get("/api/transactions?limit=100&offset=0"),
       ])
 
       setAccounts(accountsData || [])
-      setTransactions(transactionsData || [])
+      setTransactions(transactionsData?.transactions || transactionsData || [])
     } catch (error) {
       console.error("Error loading data:", error)
       setError("Failed to load account data. Please refresh the page.")


### PR DESCRIPTION
## Summary
- support optional startDate, endDate, limit and offset in all transaction API routes
- paginate transaction listings and add incremental loading to client components
- document new query options and paginated response format

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm exec tsc --noEmit` *(fails: implicit any and other existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f29cd8308325ae34be217e37444f