### PR TITLE
refactor: use supported transactions

### DIFF
--- a/app/api/accounts/route.ts
+++ b/app/api/accounts/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { sql } from "@/lib/database"
+import { sql, withTransaction } from "@/lib/database"
 import { verifySession } from "@/lib/auth"
 
 function getDeviceId(request: NextRequest): string {
@@ -115,41 +115,34 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: "An account with this name already exists" }, { status: 400 })
     }
 
-    // Start transaction to handle balance adjustment
-    const result = await sql.begin(async (sql) => {
-      // Calculate balance difference
+    const result = await withTransaction(async (client) => {
       const balanceDifference = balance - existingAccount.balance
 
-      // Update account
-      const [account] = await sql`
-        UPDATE accounts 
-        SET name = ${name.trim()}, type = ${type}, balance = ${balance}, 
-            color = ${color || "blue"}, updated_at = NOW()
-        WHERE id = ${id} AND user_id = ${userId}
-        RETURNING *
-      `
+      const { rows: accountRows } = await client.query(
+        `UPDATE accounts SET name = $1, type = $2, balance = $3, color = $4, updated_at = NOW() WHERE id = $5 AND user_id = $6 RETURNING *`,
+        [name.trim(), type, balance, color || "blue", id, userId],
+      )
+      const account = accountRows[0]
 
-      // If balance changed, create an adjustment transaction
       if (balanceDifference !== 0) {
-        // Get "Other" category for balance adjustments
-        const [otherCategory] = await sql`
-          SELECT id FROM categories 
-          WHERE user_id = ${userId} AND name = 'Other' AND type = ${balanceDifference > 0 ? "income" : "expense"}
-        `
-
+        const { rows: categoryRows } = await client.query(
+          "SELECT id FROM categories WHERE user_id = $1 AND name = 'Other' AND type = $2",
+          [userId, balanceDifference > 0 ? "income" : "expense"],
+        )
+        const otherCategory = categoryRows[0]
         if (otherCategory) {
-          await sql`
-            INSERT INTO transactions (user_id, account_id, category_id, type, amount, description, transaction_date)
-            VALUES (
-              ${userId}, 
-              ${id}, 
-              ${otherCategory.id}, 
-              ${balanceDifference > 0 ? "income" : "expense"}, 
-              ${Math.abs(balanceDifference)}, 
-              'Balance adjustment for ${name.trim()}', 
-              ${new Date().toISOString().split("T")[0]}
-            )
-          `
+          await client.query(
+            `INSERT INTO transactions (user_id, account_id, category_id, type, amount, description, transaction_date) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+            [
+              userId,
+              id,
+              otherCategory.id,
+              balanceDifference > 0 ? "income" : "expense",
+              Math.abs(balanceDifference),
+              `Balance adjustment for ${name.trim()}`,
+              new Date().toISOString().split("T")[0],
+            ],
+          )
         }
       }
 
@@ -177,29 +170,25 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: "Account ID required" }, { status: 400 })
     }
 
-    // Start transaction to delete account and all related data
-    const result = await sql.begin(async (sql) => {
-      // Check if account exists and belongs to user
-      const [account] = await sql`
-        SELECT id FROM accounts 
-        WHERE id = ${id} AND user_id = ${userId}
-      `
-
+    const result = await withTransaction(async (client) => {
+      const { rows: accountRows } = await client.query(
+        "SELECT id FROM accounts WHERE id = $1 AND user_id = $2",
+        [id, userId],
+      )
+      const account = accountRows[0]
       if (!account) {
         throw new Error("Account not found or access denied")
       }
 
-      // Delete all transactions for this account
-      await sql`
-        DELETE FROM transactions 
-        WHERE account_id = ${id} AND user_id = ${userId}
-      `
+      await client.query(
+        "DELETE FROM transactions WHERE account_id = $1 AND user_id = $2",
+        [id, userId],
+      )
 
-      // Delete the account
-      await sql`
-        DELETE FROM accounts 
-        WHERE id = ${id} AND user_id = ${userId}
-      `
+      await client.query(
+        "DELETE FROM accounts WHERE id = $1 AND user_id = $2",
+        [id, userId],
+      )
 
       return { success: true }
     })

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { sql } from "@/lib/database"
+import { sql, withTransaction } from "@/lib/database"
 import { verifySession } from "@/lib/auth"
 import { ZodError } from "zod"
 import {
@@ -95,53 +95,50 @@ export async function POST(request: NextRequest) {
       await request.json(),
     )
 
-    // Start transaction
-    const result = await sql.begin(async (sql) => {
-      // Verify account belongs to user
-      const [accountRecord] = await sql`
-        SELECT id, balance FROM accounts 
-        WHERE id = ${account} AND user_id = ${userId}
-      `
-
+    const result = await withTransaction(async (client) => {
+      const {
+        rows: accountRows,
+      } = await client.query(
+        "SELECT id, balance FROM accounts WHERE id = $1 AND user_id = $2",
+        [account, userId],
+      )
+      const accountRecord = accountRows[0]
       if (!accountRecord) {
         throw new Error("Account not found or access denied")
       }
 
-      // Get category ID
-      const [categoryRecord] = await sql`
-        SELECT id FROM categories 
-        WHERE name = ${category} AND type = ${type} AND user_id = ${userId}
-      `
-
+      const {
+        rows: categoryRows,
+      } = await client.query(
+        "SELECT id FROM categories WHERE name = $1 AND type = $2 AND user_id = $3",
+        [category, type, userId],
+      )
+      const categoryRecord = categoryRows[0]
       if (!categoryRecord) {
         throw new Error("Category not found")
       }
 
-      // For expenses, check if account has sufficient balance
-      if (type === "expense" && accountRecord.balance < amount) {
+      if (type === "expense" && Number(accountRecord.balance) < amount) {
         throw new Error("Insufficient account balance")
       }
 
-      // Insert transaction
-      const [transaction] = await sql`
-        INSERT INTO transactions (user_id, account_id, category_id, type, amount, description, transaction_date)
-        VALUES (${userId}, ${account}, ${categoryRecord.id}, ${type}, ${amount}, ${description.trim()}, ${date})
-        RETURNING *
-      `
+      const { rows: transactionRows } = await client.query(
+        `INSERT INTO transactions (user_id, account_id, category_id, type, amount, description, transaction_date)
+         VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *`,
+        [userId, account, categoryRecord.id, type, amount, description.trim(), date],
+      )
+      const transaction = transactionRows[0]
 
-      // Update account balance
       if (type === "income") {
-        await sql`
-          UPDATE accounts 
-          SET balance = balance + ${amount}, updated_at = NOW()
-          WHERE id = ${account} AND user_id = ${userId}
-        `
+        await client.query(
+          "UPDATE accounts SET balance = balance + $1, updated_at = NOW() WHERE id = $2 AND user_id = $3",
+          [amount, account, userId],
+        )
       } else {
-        await sql`
-          UPDATE accounts 
-          SET balance = balance - ${amount}, updated_at = NOW()
-          WHERE id = ${account} AND user_id = ${userId}
-        `
+        await client.query(
+          "UPDATE accounts SET balance = balance - $1, updated_at = NOW() WHERE id = $2 AND user_id = $3",
+          [amount, account, userId],
+        )
       }
 
       return transaction
@@ -176,86 +173,77 @@ export async function PUT(request: NextRequest) {
     const { id, type, amount, description, category, account, date } =
       transactionUpdateSchema.parse(await request.json())
 
-    // Start transaction
-    const result = await sql.begin(async (sql) => {
-      // Get old transaction for balance adjustment
-      const [oldTransaction] = await sql`
-        SELECT t.*, a.balance as account_balance FROM transactions t
-        LEFT JOIN accounts a ON t.account_id = a.id
-        WHERE t.id = ${id} AND t.user_id = ${userId}
-      `
-
+    const result = await withTransaction(async (client) => {
+      const {
+        rows: oldRows,
+      } = await client.query(
+        `SELECT t.*, a.balance as account_balance FROM transactions t LEFT JOIN accounts a ON t.account_id = a.id WHERE t.id = $1 AND t.user_id = $2`,
+        [id, userId],
+      )
+      const oldTransaction = oldRows[0]
       if (!oldTransaction) {
         throw new Error("Transaction not found or access denied")
       }
 
-      // Verify new account belongs to user
-      const [newAccountRecord] = await sql`
-        SELECT id, balance FROM accounts 
-        WHERE id = ${account} AND user_id = ${userId}
-      `
-
+      const {
+        rows: newAccountRows,
+      } = await client.query(
+        "SELECT id, balance FROM accounts WHERE id = $1 AND user_id = $2",
+        [account, userId],
+      )
+      const newAccountRecord = newAccountRows[0]
       if (!newAccountRecord) {
         throw new Error("Account not found or access denied")
       }
 
-      // Get category ID
-      const [categoryRecord] = await sql`
-        SELECT id FROM categories 
-        WHERE name = ${category} AND type = ${type} AND user_id = ${userId}
-      `
-
+      const {
+        rows: categoryRows,
+      } = await client.query(
+        "SELECT id FROM categories WHERE name = $1 AND type = $2 AND user_id = $3",
+        [category, type, userId],
+      )
+      const categoryRecord = categoryRows[0]
       if (!categoryRecord) {
         throw new Error("Category not found")
       }
 
-      // Reverse old transaction effect on old account
       if (oldTransaction.type === "income") {
-        await sql`
-          UPDATE accounts 
-          SET balance = balance - ${oldTransaction.amount}, updated_at = NOW()
-          WHERE id = ${oldTransaction.account_id}
-        `
+        await client.query(
+          "UPDATE accounts SET balance = balance - $1, updated_at = NOW() WHERE id = $2",
+          [oldTransaction.amount, oldTransaction.account_id],
+        )
       } else {
-        await sql`
-          UPDATE accounts 
-          SET balance = balance + ${oldTransaction.amount}, updated_at = NOW()
-          WHERE id = ${oldTransaction.account_id}
-        `
+        await client.query(
+          "UPDATE accounts SET balance = balance + $1, updated_at = NOW() WHERE id = $2",
+          [oldTransaction.amount, oldTransaction.account_id],
+        )
       }
 
-      // Check if new account has sufficient balance for expense
-      const [updatedAccountBalance] = await sql`
-        SELECT balance FROM accounts WHERE id = ${account}
-      `
-
-      if (type === "expense" && updatedAccountBalance.balance < amount) {
+      const { rows: updatedAccountRows } = await client.query(
+        "SELECT balance FROM accounts WHERE id = $1",
+        [account],
+      )
+      const updatedAccountBalance = updatedAccountRows[0]
+      if (type === "expense" && Number(updatedAccountBalance.balance) < amount) {
         throw new Error("Insufficient account balance for this transaction")
       }
 
-      // Update transaction
-      const [transaction] = await sql`
-        UPDATE transactions 
-        SET type = ${type}, amount = ${amount}, description = ${description.trim()}, 
-            category_id = ${categoryRecord.id}, account_id = ${account}, 
-            transaction_date = ${date}, updated_at = NOW()
-        WHERE id = ${id} AND user_id = ${userId}
-        RETURNING *
-      `
+      const { rows: transactionRows } = await client.query(
+        `UPDATE transactions SET type = $1, amount = $2, description = $3, category_id = $4, account_id = $5, transaction_date = $6, updated_at = NOW() WHERE id = $7 AND user_id = $8 RETURNING *`,
+        [type, amount, description.trim(), categoryRecord.id, account, date, id, userId],
+      )
+      const transaction = transactionRows[0]
 
-      // Apply new transaction effect on new account
       if (type === "income") {
-        await sql`
-          UPDATE accounts 
-          SET balance = balance + ${amount}, updated_at = NOW()
-          WHERE id = ${account}
-        `
+        await client.query(
+          "UPDATE accounts SET balance = balance + $1, updated_at = NOW() WHERE id = $2",
+          [amount, account],
+        )
       } else {
-        await sql`
-          UPDATE accounts 
-          SET balance = balance - ${amount}, updated_at = NOW()
-          WHERE id = ${account}
-        `
+        await client.query(
+          "UPDATE accounts SET balance = balance - $1, updated_at = NOW() WHERE id = $2",
+          [amount, account],
+        )
       }
 
       return transaction
@@ -290,37 +278,31 @@ export async function DELETE(request: NextRequest) {
     const rawQuery = Object.fromEntries(new URL(request.url).searchParams.entries())
     const { id } = transactionIdSchema.parse(rawQuery)
 
-    // Start transaction
-    const result = await sql.begin(async (sql) => {
-      // Get transaction for balance adjustment
-      const [transaction] = await sql`
-        SELECT * FROM transactions
-        WHERE id = ${id} AND user_id = ${userId}
-      `
-
+    const result = await withTransaction(async (client) => {
+      const { rows } = await client.query(
+        "SELECT * FROM transactions WHERE id = $1 AND user_id = $2",
+        [id, userId],
+      )
+      const transaction = rows[0]
       if (!transaction) {
         throw new Error("Transaction not found or access denied")
       }
 
-      // Delete transaction
-      await sql`
-        DELETE FROM transactions 
-        WHERE id = ${id} AND user_id = ${userId}
-      `
+      await client.query(
+        "DELETE FROM transactions WHERE id = $1 AND user_id = $2",
+        [id, userId],
+      )
 
-      // Adjust account balance (reverse the transaction effect)
       if (transaction.type === "income") {
-        await sql`
-          UPDATE accounts 
-          SET balance = balance - ${transaction.amount}, updated_at = NOW()
-          WHERE id = ${transaction.account_id}
-        `
+        await client.query(
+          "UPDATE accounts SET balance = balance - $1, updated_at = NOW() WHERE id = $2",
+          [transaction.amount, transaction.account_id],
+        )
       } else {
-        await sql`
-          UPDATE accounts 
-          SET balance = balance + ${transaction.amount}, updated_at = NOW()
-          WHERE id = ${transaction.account_id}
-        `
+        await client.query(
+          "UPDATE accounts SET balance = balance + $1, updated_at = NOW() WHERE id = $2",
+          [transaction.amount, transaction.account_id],
+        )
       }
 
       return { success: true }

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -1,4 +1,7 @@
-import { neon } from "@neondatabase/serverless"
+import { neon, Client, neonConfig } from "@neondatabase/serverless"
+import ws from "ws"
+
+neonConfig.webSocketConstructor = ws
 
 if (!process.env.DATABASE_URL) {
   throw new Error("DATABASE_URL is not set")
@@ -7,6 +10,22 @@ if (!process.env.DATABASE_URL) {
 const sql = neon(process.env.DATABASE_URL)
 
 export { sql }
+
+export async function withTransaction<T>(fn: (client: Client) => Promise<T>): Promise<T> {
+  const client = new Client(process.env.DATABASE_URL)
+  await client.connect()
+  try {
+    await client.query("BEGIN")
+    const result = await fn(client)
+    await client.query("COMMIT")
+    return result
+  } catch (error) {
+    await client.query("ROLLBACK")
+    throw error
+  } finally {
+    await client.end()
+  }
+}
 
 // Database types
 export interface User {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.6",
+    "ws": "^8.18.3",
     "xlsx": "latest",
     "zod": "^3.24.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
       vaul:
         specifier: ^0.9.6
         version: 0.9.6(@types/react-dom@19.0.0)(@types/react@19.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      ws:
+        specifier: ^8.18.3
+        version: 8.18.3
       xlsx:
         specifier: latest
         version: 0.18.5
@@ -2592,6 +2595,18 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xlsx@0.18.5:
     resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
     engines: {node: '>=0.8'}
@@ -4880,6 +4895,8 @@ snapshots:
       ansi-styles: 6.2.1
       string-width: 5.1.2
       strip-ansi: 7.1.0
+
+  ws@8.18.3: {}
 
   xlsx@0.18.5:
     dependencies:


### PR DESCRIPTION
## Summary
- replace deprecated sql.begin with WebSocket `Client` transactions
- add reusable `withTransaction` helper
- add ws dependency

## Testing
- `pnpm test`
- `pnpm lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c7663c241c83258ed3b7786cab43b2