### PR TITLE
Handle database connection loss

### DIFF
--- a/app/api/accounts/route.ts
+++ b/app/api/accounts/route.ts
@@ -115,39 +115,54 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: "An account with this name already exists" }, { status: 400 })
     }
 
-    const result = await withTransaction(async (client) => {
-      const balanceDifference = balance - existingAccount.balance
+    let result
+    try {
+      result = await withTransaction(async (client) => {
+        const balanceDifference = balance - existingAccount.balance
 
-      const { rows: accountRows } = await client.query(
-        `UPDATE accounts SET name = $1, type = $2, balance = $3, color = $4, updated_at = NOW() WHERE id = $5 AND user_id = $6 RETURNING *`,
-        [name.trim(), type, balance, color || "blue", id, userId],
-      )
-      const account = accountRows[0]
-
-      if (balanceDifference !== 0) {
-        const { rows: categoryRows } = await client.query(
-          "SELECT id FROM categories WHERE user_id = $1 AND name = 'Other' AND type = $2",
-          [userId, balanceDifference > 0 ? "income" : "expense"],
+        const { rows: accountRows } = await client.query(
+          `UPDATE accounts SET name = $1, type = $2, balance = $3, color = $4, updated_at = NOW() WHERE id = $5 AND user_id = $6 RETURNING *`,
+          [name.trim(), type, balance, color || "blue", id, userId],
         )
-        const otherCategory = categoryRows[0]
-        if (otherCategory) {
-          await client.query(
-            `INSERT INTO transactions (user_id, account_id, category_id, type, amount, description, transaction_date) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-            [
-              userId,
-              id,
-              otherCategory.id,
-              balanceDifference > 0 ? "income" : "expense",
-              Math.abs(balanceDifference),
-              `Balance adjustment for ${name.trim()}`,
-              new Date().toISOString().split("T")[0],
-            ],
-          )
-        }
-      }
+        const account = accountRows[0]
 
-      return account
-    })
+        if (balanceDifference !== 0) {
+          const { rows: categoryRows } = await client.query(
+            "SELECT id FROM categories WHERE user_id = $1 AND name = 'Other' AND type = $2",
+            [userId, balanceDifference > 0 ? "income" : "expense"],
+          )
+          const otherCategory = categoryRows[0]
+          if (otherCategory) {
+            await client.query(
+              `INSERT INTO transactions (user_id, account_id, category_id, type, amount, description, transaction_date) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+              [
+                userId,
+                id,
+                otherCategory.id,
+                balanceDifference > 0 ? "income" : "expense",
+                Math.abs(balanceDifference),
+                `Balance adjustment for ${name.trim()}`,
+                new Date().toISOString().split("T")[0],
+              ],
+            )
+          }
+        }
+
+        return account
+      })
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes("Connection terminated unexpectedly")
+      ) {
+        console.error("Update account error:", error)
+        return NextResponse.json(
+          { error: "Database connection lost; please retry" },
+          { status: 503 },
+        )
+      }
+      throw error
+    }
 
     return NextResponse.json(result)
   } catch (error) {
@@ -170,28 +185,43 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: "Account ID required" }, { status: 400 })
     }
 
-    const result = await withTransaction(async (client) => {
-      const { rows: accountRows } = await client.query(
-        "SELECT id FROM accounts WHERE id = $1 AND user_id = $2",
-        [id, userId],
-      )
-      const account = accountRows[0]
-      if (!account) {
-        throw new Error("Account not found or access denied")
+    let result
+    try {
+      result = await withTransaction(async (client) => {
+        const { rows: accountRows } = await client.query(
+          "SELECT id FROM accounts WHERE id = $1 AND user_id = $2",
+          [id, userId],
+        )
+        const account = accountRows[0]
+        if (!account) {
+          throw new Error("Account not found or access denied")
+        }
+
+        await client.query(
+          "DELETE FROM transactions WHERE account_id = $1 AND user_id = $2",
+          [id, userId],
+        )
+
+        await client.query(
+          "DELETE FROM accounts WHERE id = $1 AND user_id = $2",
+          [id, userId],
+        )
+
+        return { success: true }
+      })
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes("Connection terminated unexpectedly")
+      ) {
+        console.error("Delete account error:", error)
+        return NextResponse.json(
+          { error: "Database connection lost; please retry" },
+          { status: 503 },
+        )
       }
-
-      await client.query(
-        "DELETE FROM transactions WHERE account_id = $1 AND user_id = $2",
-        [id, userId],
-      )
-
-      await client.query(
-        "DELETE FROM accounts WHERE id = $1 AND user_id = $2",
-        [id, userId],
-      )
-
-      return { success: true }
-    })
+      throw error
+    }
 
     return NextResponse.json(result)
   } catch (error) {

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -95,54 +95,69 @@ export async function POST(request: NextRequest) {
       await request.json(),
     )
 
-    const result = await withTransaction(async (client) => {
-      const {
-        rows: accountRows,
-      } = await client.query(
-        "SELECT id, balance FROM accounts WHERE id = $1 AND user_id = $2",
-        [account, userId],
-      )
-      const accountRecord = accountRows[0]
-      if (!accountRecord) {
-        throw new Error("Account not found or access denied")
-      }
-
-      const {
-        rows: categoryRows,
-      } = await client.query(
-        "SELECT id FROM categories WHERE name = $1 AND type = $2 AND user_id = $3",
-        [category, type, userId],
-      )
-      const categoryRecord = categoryRows[0]
-      if (!categoryRecord) {
-        throw new Error("Category not found")
-      }
-
-      if (type === "expense" && Number(accountRecord.balance) < amount) {
-        throw new Error("Insufficient account balance")
-      }
-
-      const { rows: transactionRows } = await client.query(
-        `INSERT INTO transactions (user_id, account_id, category_id, type, amount, description, transaction_date)
-         VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *`,
-        [userId, account, categoryRecord.id, type, amount, description.trim(), date],
-      )
-      const transaction = transactionRows[0]
-
-      if (type === "income") {
-        await client.query(
-          "UPDATE accounts SET balance = balance + $1, updated_at = NOW() WHERE id = $2 AND user_id = $3",
-          [amount, account, userId],
+    let result
+    try {
+      result = await withTransaction(async (client) => {
+        const {
+          rows: accountRows,
+        } = await client.query(
+          "SELECT id, balance FROM accounts WHERE id = $1 AND user_id = $2",
+          [account, userId],
         )
-      } else {
-        await client.query(
-          "UPDATE accounts SET balance = balance - $1, updated_at = NOW() WHERE id = $2 AND user_id = $3",
-          [amount, account, userId],
+        const accountRecord = accountRows[0]
+        if (!accountRecord) {
+          throw new Error("Account not found or access denied")
+        }
+
+        const {
+          rows: categoryRows,
+        } = await client.query(
+          "SELECT id FROM categories WHERE name = $1 AND type = $2 AND user_id = $3",
+          [category, type, userId],
+        )
+        const categoryRecord = categoryRows[0]
+        if (!categoryRecord) {
+          throw new Error("Category not found")
+        }
+
+        if (type === "expense" && Number(accountRecord.balance) < amount) {
+          throw new Error("Insufficient account balance")
+        }
+
+        const { rows: transactionRows } = await client.query(
+          `INSERT INTO transactions (user_id, account_id, category_id, type, amount, description, transaction_date)
+           VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *`,
+          [userId, account, categoryRecord.id, type, amount, description.trim(), date],
+        )
+        const transaction = transactionRows[0]
+
+        if (type === "income") {
+          await client.query(
+            "UPDATE accounts SET balance = balance + $1, updated_at = NOW() WHERE id = $2 AND user_id = $3",
+            [amount, account, userId],
+          )
+        } else {
+          await client.query(
+            "UPDATE accounts SET balance = balance - $1, updated_at = NOW() WHERE id = $2 AND user_id = $3",
+            [amount, account, userId],
+          )
+        }
+
+        return transaction
+      })
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes("Connection terminated unexpectedly")
+      ) {
+        console.error("Create transaction error:", error)
+        return NextResponse.json(
+          { error: "Database connection lost; please retry" },
+          { status: 503 },
         )
       }
-
-      return transaction
-    })
+      throw error
+    }
 
     return NextResponse.json(result)
   } catch (error) {
@@ -173,81 +188,96 @@ export async function PUT(request: NextRequest) {
     const { id, type, amount, description, category, account, date } =
       transactionUpdateSchema.parse(await request.json())
 
-    const result = await withTransaction(async (client) => {
-      const {
-        rows: oldRows,
-      } = await client.query(
-        `SELECT t.*, a.balance as account_balance FROM transactions t LEFT JOIN accounts a ON t.account_id = a.id WHERE t.id = $1 AND t.user_id = $2`,
-        [id, userId],
-      )
-      const oldTransaction = oldRows[0]
-      if (!oldTransaction) {
-        throw new Error("Transaction not found or access denied")
-      }
-
-      const {
-        rows: newAccountRows,
-      } = await client.query(
-        "SELECT id, balance FROM accounts WHERE id = $1 AND user_id = $2",
-        [account, userId],
-      )
-      const newAccountRecord = newAccountRows[0]
-      if (!newAccountRecord) {
-        throw new Error("Account not found or access denied")
-      }
-
-      const {
-        rows: categoryRows,
-      } = await client.query(
-        "SELECT id FROM categories WHERE name = $1 AND type = $2 AND user_id = $3",
-        [category, type, userId],
-      )
-      const categoryRecord = categoryRows[0]
-      if (!categoryRecord) {
-        throw new Error("Category not found")
-      }
-
-      if (oldTransaction.type === "income") {
-        await client.query(
-          "UPDATE accounts SET balance = balance - $1, updated_at = NOW() WHERE id = $2",
-          [oldTransaction.amount, oldTransaction.account_id],
+    let result
+    try {
+      result = await withTransaction(async (client) => {
+        const {
+          rows: oldRows,
+        } = await client.query(
+          `SELECT t.*, a.balance as account_balance FROM transactions t LEFT JOIN accounts a ON t.account_id = a.id WHERE t.id = $1 AND t.user_id = $2`,
+          [id, userId],
         )
-      } else {
-        await client.query(
-          "UPDATE accounts SET balance = balance + $1, updated_at = NOW() WHERE id = $2",
-          [oldTransaction.amount, oldTransaction.account_id],
+        const oldTransaction = oldRows[0]
+        if (!oldTransaction) {
+          throw new Error("Transaction not found or access denied")
+        }
+
+        const {
+          rows: newAccountRows,
+        } = await client.query(
+          "SELECT id, balance FROM accounts WHERE id = $1 AND user_id = $2",
+          [account, userId],
+        )
+        const newAccountRecord = newAccountRows[0]
+        if (!newAccountRecord) {
+          throw new Error("Account not found or access denied")
+        }
+
+        const {
+          rows: categoryRows,
+        } = await client.query(
+          "SELECT id FROM categories WHERE name = $1 AND type = $2 AND user_id = $3",
+          [category, type, userId],
+        )
+        const categoryRecord = categoryRows[0]
+        if (!categoryRecord) {
+          throw new Error("Category not found")
+        }
+
+        if (oldTransaction.type === "income") {
+          await client.query(
+            "UPDATE accounts SET balance = balance - $1, updated_at = NOW() WHERE id = $2",
+            [oldTransaction.amount, oldTransaction.account_id],
+          )
+        } else {
+          await client.query(
+            "UPDATE accounts SET balance = balance + $1, updated_at = NOW() WHERE id = $2",
+            [oldTransaction.amount, oldTransaction.account_id],
+          )
+        }
+
+        const { rows: updatedAccountRows } = await client.query(
+          "SELECT balance FROM accounts WHERE id = $1",
+          [account],
+        )
+        const updatedAccountBalance = updatedAccountRows[0]
+        if (type === "expense" && Number(updatedAccountBalance.balance) < amount) {
+          throw new Error("Insufficient account balance for this transaction")
+        }
+
+        const { rows: transactionRows } = await client.query(
+          `UPDATE transactions SET type = $1, amount = $2, description = $3, category_id = $4, account_id = $5, transaction_date = $6, updated_at = NOW() WHERE id = $7 AND user_id = $8 RETURNING *`,
+          [type, amount, description.trim(), categoryRecord.id, account, date, id, userId],
+        )
+        const transaction = transactionRows[0]
+
+        if (type === "income") {
+          await client.query(
+            "UPDATE accounts SET balance = balance + $1, updated_at = NOW() WHERE id = $2",
+            [amount, account],
+          )
+        } else {
+          await client.query(
+            "UPDATE accounts SET balance = balance - $1, updated_at = NOW() WHERE id = $2",
+            [amount, account],
+          )
+        }
+
+        return transaction
+      })
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes("Connection terminated unexpectedly")
+      ) {
+        console.error("Update transaction error:", error)
+        return NextResponse.json(
+          { error: "Database connection lost; please retry" },
+          { status: 503 },
         )
       }
-
-      const { rows: updatedAccountRows } = await client.query(
-        "SELECT balance FROM accounts WHERE id = $1",
-        [account],
-      )
-      const updatedAccountBalance = updatedAccountRows[0]
-      if (type === "expense" && Number(updatedAccountBalance.balance) < amount) {
-        throw new Error("Insufficient account balance for this transaction")
-      }
-
-      const { rows: transactionRows } = await client.query(
-        `UPDATE transactions SET type = $1, amount = $2, description = $3, category_id = $4, account_id = $5, transaction_date = $6, updated_at = NOW() WHERE id = $7 AND user_id = $8 RETURNING *`,
-        [type, amount, description.trim(), categoryRecord.id, account, date, id, userId],
-      )
-      const transaction = transactionRows[0]
-
-      if (type === "income") {
-        await client.query(
-          "UPDATE accounts SET balance = balance + $1, updated_at = NOW() WHERE id = $2",
-          [amount, account],
-        )
-      } else {
-        await client.query(
-          "UPDATE accounts SET balance = balance - $1, updated_at = NOW() WHERE id = $2",
-          [amount, account],
-        )
-      }
-
-      return transaction
-    })
+      throw error
+    }
 
     return NextResponse.json(result)
   } catch (error) {
@@ -278,35 +308,50 @@ export async function DELETE(request: NextRequest) {
     const rawQuery = Object.fromEntries(new URL(request.url).searchParams.entries())
     const { id } = transactionIdSchema.parse(rawQuery)
 
-    const result = await withTransaction(async (client) => {
-      const { rows } = await client.query(
-        "SELECT * FROM transactions WHERE id = $1 AND user_id = $2",
-        [id, userId],
-      )
-      const transaction = rows[0]
-      if (!transaction) {
-        throw new Error("Transaction not found or access denied")
-      }
-
-      await client.query(
-        "DELETE FROM transactions WHERE id = $1 AND user_id = $2",
-        [id, userId],
-      )
-
-      if (transaction.type === "income") {
-        await client.query(
-          "UPDATE accounts SET balance = balance - $1, updated_at = NOW() WHERE id = $2",
-          [transaction.amount, transaction.account_id],
+    let result
+    try {
+      result = await withTransaction(async (client) => {
+        const { rows } = await client.query(
+          "SELECT * FROM transactions WHERE id = $1 AND user_id = $2",
+          [id, userId],
         )
-      } else {
+        const transaction = rows[0]
+        if (!transaction) {
+          throw new Error("Transaction not found or access denied")
+        }
+
         await client.query(
-          "UPDATE accounts SET balance = balance + $1, updated_at = NOW() WHERE id = $2",
-          [transaction.amount, transaction.account_id],
+          "DELETE FROM transactions WHERE id = $1 AND user_id = $2",
+          [id, userId],
+        )
+
+        if (transaction.type === "income") {
+          await client.query(
+            "UPDATE accounts SET balance = balance - $1, updated_at = NOW() WHERE id = $2",
+            [transaction.amount, transaction.account_id],
+          )
+        } else {
+          await client.query(
+            "UPDATE accounts SET balance = balance + $1, updated_at = NOW() WHERE id = $2",
+            [transaction.amount, transaction.account_id],
+          )
+        }
+
+        return { success: true }
+      })
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes("Connection terminated unexpectedly")
+      ) {
+        console.error("Delete transaction error:", error)
+        return NextResponse.json(
+          { error: "Database connection lost; please retry" },
+          { status: 503 },
         )
       }
-
-      return { success: true }
-    })
+      throw error
+    }
 
     return NextResponse.json(result)
   } catch (error) {


### PR DESCRIPTION
## Summary
- wrap transaction-related database calls in try/catch to handle unexpected connection termination
- return a 503 'Database connection lost; please retry' message when the connection drops
- log connection loss for debugging

## Testing
- `pnpm test`
- `pnpm lint` *(fails: prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ace3e3c48325893fbf6064fe1859