### PR TITLE
Handle transaction API errors safely

### DIFF
--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -143,13 +143,15 @@ export async function POST(request: NextRequest) {
     }
     console.error("Create transaction error:", error)
 
+    const message = error instanceof Error ? error.message : String(error)
+
     // Return specific error messages for validation failures
-    if (error.message.includes("not found") || error.message.includes("access denied")) {
-      return NextResponse.json({ error: error.message }, { status: 404 })
+    if (message.includes("not found") || message.includes("access denied")) {
+      return NextResponse.json({ error: message }, { status: 404 })
     }
 
-    if (error.message.includes("Insufficient")) {
-      return NextResponse.json({ error: error.message }, { status: 400 })
+    if (message.includes("Insufficient")) {
+      return NextResponse.json({ error: message }, { status: 400 })
     }
 
     return NextResponse.json({ error: "Failed to create transaction" }, { status: 500 })
@@ -233,13 +235,15 @@ export async function PUT(request: NextRequest) {
     }
     console.error("Update transaction error:", error)
 
+    const message = error instanceof Error ? error.message : String(error)
+
     // Return specific error messages for validation failures
-    if (error.message.includes("not found") || error.message.includes("access denied")) {
-      return NextResponse.json({ error: error.message }, { status: 404 })
+    if (message.includes("not found") || message.includes("access denied")) {
+      return NextResponse.json({ error: message }, { status: 404 })
     }
 
-    if (error.message.includes("Insufficient")) {
-      return NextResponse.json({ error: error.message }, { status: 400 })
+    if (message.includes("Insufficient")) {
+      return NextResponse.json({ error: message }, { status: 400 })
     }
 
     return NextResponse.json({ error: "Failed to update transaction" }, { status: 500 })
@@ -288,8 +292,10 @@ export async function DELETE(request: NextRequest) {
     }
     console.error("Delete transaction error:", error)
 
-    if (error.message.includes("not found") || error.message.includes("access denied")) {
-      return NextResponse.json({ error: error.message }, { status: 404 })
+    const message = error instanceof Error ? error.message : String(error)
+
+    if (message.includes("not found") || message.includes("access denied")) {
+      return NextResponse.json({ error: message }, { status: 404 })
     }
 
     return NextResponse.json({ error: "Failed to delete transaction" }, { status: 500 })


### PR DESCRIPTION
## Summary
- derive a stable message string from caught errors in the transaction API routes
- reuse the derived message for string comparisons and JSON responses to avoid secondary failures

## Testing
- pnpm lint *(fails: Next.js lint prompts for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c93f02e068832596b3b68e0588ceae