### PR TITLE
Secure import API requests and handle auth failures

### DIFF
--- a/app/api/import/route.ts
+++ b/app/api/import/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { sql } from "@/lib/database"
-import { getUserId } from "@/lib/auth"
+import { verifySession } from "@/lib/auth"
 import * as XLSX from "xlsx"
 
 interface ImportRow {
@@ -13,6 +13,18 @@ interface ImportRow {
   [key: string]: any
 }
 
+function getDeviceId(request: NextRequest): string {
+  return request.headers.get("x-device-id") || request.headers.get("user-agent") || "unknown-device"
+}
+
+async function getUserFromRequest(request: NextRequest): Promise<string | null> {
+  const sessionToken = request.headers.get("authorization")?.replace("Bearer ", "")
+  if (!sessionToken) return null
+
+  const deviceId = getDeviceId(request)
+  return await verifySession(sessionToken, deviceId)
+}
+
 interface ImportError {
   row: number
   field: string
@@ -22,7 +34,7 @@ interface ImportError {
 
 export async function POST(request: NextRequest) {
   try {
-    const userId = await getUserId()
+    const userId = await getUserFromRequest(request)
     if (!userId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     }

--- a/components/bulk-import.tsx
+++ b/components/bulk-import.tsx
@@ -3,6 +3,7 @@
 import type React from "react"
 
 import { useState, useRef } from "react"
+import { apiClient } from "@/lib/api-client"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
@@ -44,40 +45,36 @@ export function BulkImport() {
     setUploadProgress(0)
     setImportResult(null)
 
+    const progressInterval = setInterval(() => {
+      setUploadProgress((prev) => Math.min(prev + 10, 90))
+    }, 200)
+
     try {
       const formData = new FormData()
       formData.append("file", file)
 
-      // Simulate progress
-      const progressInterval = setInterval(() => {
-        setUploadProgress((prev) => Math.min(prev + 10, 90))
-      }, 200)
+      const result = await apiClient.postFormData("/api/import", formData)
 
-      const response = await fetch("/api/import", {
-        method: "POST",
-        body: formData,
-      })
-
-      clearInterval(progressInterval)
       setUploadProgress(100)
-
-      const result = await response.json()
-
-      if (response.ok) {
-        setImportResult(result)
-      } else {
-        throw new Error(result.error || "Import failed")
-      }
+      setImportResult(result)
     } catch (error) {
       console.error("Import error:", error)
+      const status = (error as { status?: number } | undefined)?.status
+      let message = error instanceof Error ? error.message : "Import failed"
+
+      if (status === 401) {
+        message = "Your session has expired. Please log in again."
+      }
+
       setImportResult({
         success: false,
         totalRows: 0,
         successfulRows: 0,
         failedRows: 0,
-        errors: [{ row: 0, field: "general", message: error.message, data: null }],
+        errors: [{ row: 0, field: "general", message, data: null }],
       })
     } finally {
+      clearInterval(progressInterval)
       setIsUploading(false)
       setTimeout(() => setUploadProgress(0), 2000)
     }

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -149,9 +149,8 @@ class ApiClient {
     return () => this.syncCallbacks.delete(callback)
   }
 
-  private getHeaders(): HeadersInit {
-    const headers: HeadersInit = {
-      "Content-Type": "application/json",
+  private getAuthHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
       "X-Device-ID": this.deviceId,
     }
 
@@ -163,6 +162,14 @@ class ApiClient {
       headers.Authorization = `Bearer ${this.sessionToken}`
     }
 
+    return headers
+  }
+
+  private getHeaders(contentType: string | null = "application/json"): Record<string, string> {
+    const headers = this.getAuthHeaders()
+    if (contentType) {
+      headers["Content-Type"] = contentType
+    }
     return headers
   }
 
@@ -331,6 +338,48 @@ class ApiClient {
     }
 
     return result
+  }
+
+  async postFormData(endpoint: string, formData: FormData): Promise<any> {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: this.getHeaders(null),
+      body: formData,
+    })
+
+    let data: any = null
+    try {
+      data = await response.json()
+    } catch (error) {
+      data = null
+    }
+
+    if (response.status === 401) {
+      this.clearSession()
+      const errorMessage = data?.error || "Unauthorized"
+      const authError = new Error(errorMessage)
+      ;(authError as any).status = response.status
+      throw authError
+    }
+
+    if (!response.ok) {
+      const errorMessage = data?.error || "Request failed"
+      const requestError = new Error(errorMessage)
+      ;(requestError as any).status = response.status
+      throw requestError
+    }
+
+    if (
+      response.ok &&
+      (endpoint.includes("/transactions") ||
+        endpoint.includes("/accounts") ||
+        endpoint.includes("/budgets") ||
+        endpoint.includes("/import"))
+    ) {
+      this.triggerSync()
+    }
+
+    return data
   }
 
   async put(endpoint: string, data: any): Promise<any> {


### PR DESCRIPTION
## Summary
- authenticate the import API route with verifySession using device headers
- extend the API client to build auth headers for form posts and add a FormData helper
- switch the bulk import UI to the API client helper and surface meaningful authorization errors

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cad27d1bb883259d791d025ae753db